### PR TITLE
fix: missing dependencies for https support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ define Package/$(PKG_NAME)
 		+iptables \
 		+iptables-mod-extra \
 		+iptables-mod-tproxy \
-		+dnsmasq 
+		+dnsmasq \
+		+ca-bundle
 	USERID:=clash=7890:clash=7890
 endef
 


### PR DESCRIPTION
 Missing dependencies for https support