### PR TITLE
fix: make iptables-mod-extra as a optional dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ define Package/$(PKG_NAME)
 	URL:=https://github.com/dreamacro/clash
 	DEPENDS:=$(GO_ARCH_DEPENDS) \
 		+iptables \
-		+iptables-mod-extra \
 		+iptables-mod-tproxy \
 		+libuci-lua \
 		+lyaml \

--- a/files/firewall.include
+++ b/files/firewall.include
@@ -49,7 +49,7 @@ for addr in $(bypass_address); do
 	iptables_bypass_rule "CLASH_LOCAL" "$addr"
 done
 
-[ -x "/sbin/ujail" ] && {
+[ -x "/sbin/ujail" ] && (opkg list-installed | grep "iptables-mod-extra" >/dev/null) && {
 	$IPTABLES -t mangle -I CLASH_LOCAL -m owner --uid-owner "clash" -j RETURN
 	$IPTABLES -t mangle -A CLASH_LOCAL -p udp -j MARK \
 		--set-mark "$tproxy_mark"


### PR DESCRIPTION
make iptables-mod-extra as a optional dependency