### PR TITLE
fix: bump clash version from 1.9.0 to 1.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,14 +75,14 @@ define Package/$(PKG_NAME)/conffiles
 /etc/config/clash
 endef
 
-COUNTRY_MMDB_VER=20211212
+COUNTRY_MMDB_VER=20220312
 COUNTRY_MMDB_FILE:=Country.$(COUNTRY_MMDB_VER).mmdb
 
 define Download/country_mmdb
 	URL:=https://github.com/Dreamacro/maxmind-geoip/releases/download/$(COUNTRY_MMDB_VER)/
 	URL_FILE:=Country.mmdb
 	FILE:=$(COUNTRY_MMDB_FILE)
-	HASH:=79c666f2863a538dd51d9e4f017a37a5a7f17f1640c2dc3bb15f9b4c4280f99a
+	HASH:=5cac630df34fb6554fbc233e2e3633e1d5afe70bd66a195ead0739838fd337a5
 endef
 
 YACD_DASHBOARD_VER=0.3.4

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clash
-PKG_VERSION:=1.9.0
+PKG_VERSION:=1.10.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Dreamacro/clash/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a276b1e7247e847fe44fe336a67bdecbb442748a1e7fa01d9c1ce0d52f9168ef
+PKG_HASH:=40205e152ce73984a29f1888a1f235cb653f03a751ae5062b88b4b4076d5e87b
 
 PKG_MAINTAINER:=Chandelure Wang <me@chandelure.com>
 PKG_LICENSE:=GPL-3.0-only


### PR DESCRIPTION
bump clash version from 1.9.0 to 1.10.0