### PR TITLE
build: bump clash version from 1.10.0 to 1.10.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clash
-PKG_VERSION:=1.10.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.10.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Dreamacro/clash/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=40205e152ce73984a29f1888a1f235cb653f03a751ae5062b88b4b4076d5e87b
+PKG_HASH:=b56c6f978f43257da2663b8e11c219d08c16bbfc7704dd8bfdd8c4006f138c0d
 
 PKG_MAINTAINER:=Chandelure Wang <me@chandelure.com>
 PKG_LICENSE:=GPL-3.0-only


### PR DESCRIPTION
[Release Note](https://github.com/Dreamacro/clash/releases/tag/v1.10.6)