### PR TITLE
fix: fail to set the http proxy port to null

### DIFF
--- a/files/build_conf.lua
+++ b/files/build_conf.lua
@@ -147,7 +147,7 @@ local function update_dns(profile)
 end
 
 local function drop_useless(profile)
-    profile["http-port"] = nil
+    profile["port"] = nil
     profile["socks-port"] = nil
     profile["redir-port"] = nil
     profile["external-ui"] = nil


### PR DESCRIPTION
clash profiles contain:

```yaml
port: 7890
```

Log

```plain
clash[2579]: time="" level=error msg="Start Mixed(http+socks) server error: listen tcp 0.0.0.0:7890: bind: address already in use"
```